### PR TITLE
Erste Server-Basis und aktualisierte Anleitung

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+pytest_cache/
+storage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,3 +82,13 @@ user_folders:
 - Container-Daten wie `/var/lib/docker` nur sichern, falls erforderlich.
 
 Weitere Ideen wie Kompression, Verschlüsselung oder Multi-Storage können später umgesetzt werden. Details stehen in `ideas.md`.
+
+## Entwicklungsplan: Server/Client-Architektur
+Dieser Abschnitt fasst die grobe Planung zusammen, die aus `ideas.md` und den bisherigen Diskussionen hervorgeht.
+
+1. **Server auf Linux**: Umsetzung mit FastAPI und uvicorn. Token-Authentifizierung; Nutzer werden beim Login automatisch angelegt.
+2. **Clients**: Windows und Linux werden unterstützt. Beim ersten Start registriert sich der Client selbst und führt ein Vollbackup durch.
+3. **API-Endpunkte**: `/api/login`, `/api/upload`, `/api/check`, `/api/list`, `/api/restore`. Alle Aktionen erfolgen per HTTPS.
+4. **Speicherstruktur**: Pro Benutzer ein eigener Ordner unterhalb von `storage/`; Versionierung und Hash-basierte Deduplikation werden später ausgebaut.
+
+Die anfängliche Implementierung konzentriert sich auf ein minimales Gerüst des Servers. Weitere Features können Schritt für Schritt ergänzt werden.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # AsgardBackup
 A simple but Thunderous Backup Solution
+
+## Start des Servers
+
+Nach Installation der Abhängigkeiten aus `requirements.txt` lässt sich der Server mit folgendem Befehl starten:
+
+```bash
+uvicorn server:app --reload
+```
+
+Die API steht danach auf Port 8000 zur Verfügung.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+python-multipart

--- a/server.py
+++ b/server.py
@@ -1,0 +1,73 @@
+from fastapi import FastAPI, UploadFile, File, HTTPException, Header
+from fastapi.responses import FileResponse
+import os
+import secrets
+import hashlib
+
+app = FastAPI(title="AsgardBackup Server")
+
+STORAGE_ROOT = os.path.join(os.path.dirname(__file__), "storage")
+TOKENS = {}
+
+
+def get_username(x_token: str | None = Header(None)) -> str:
+    if x_token is None or x_token not in TOKENS:
+        raise HTTPException(status_code=401, detail="Ungültiger Token")
+    return TOKENS[x_token]
+
+
+@app.post("/api/login")
+async def login(username: str):
+    token = secrets.token_hex(16)
+    TOKENS[token] = username
+    os.makedirs(os.path.join(STORAGE_ROOT, username), exist_ok=True)
+    return {"token": token}
+
+
+@app.post("/api/upload")
+async def upload(file: UploadFile = File(...), username: str = Header(...), x_token: str | None = Header(None)):
+    user = get_username(x_token)
+    if user != username:
+        raise HTTPException(status_code=403, detail="Token passt nicht zum Benutzer")
+    user_dir = os.path.join(STORAGE_ROOT, user)
+    os.makedirs(user_dir, exist_ok=True)
+    file_path = os.path.join(user_dir, file.filename)
+    with open(file_path, "wb") as f:
+        f.write(await file.read())
+    return {"status": "hochgeladen"}
+
+
+@app.post("/api/check")
+async def check(filename: str, filehash: str, x_token: str | None = Header(None)):
+    user = get_username(x_token)
+    file_path = os.path.join(STORAGE_ROOT, user, filename)
+    if not os.path.exists(file_path):
+        return {"exists": False}
+    with open(file_path, "rb") as f:
+        data = f.read()
+    existing_hash = hashlib.sha256(data).hexdigest()
+    return {"exists": existing_hash == filehash}
+
+
+@app.get("/api/list")
+async def list_files(x_token: str | None = Header(None)):
+    user = get_username(x_token)
+    user_dir = os.path.join(STORAGE_ROOT, user)
+    files = os.listdir(user_dir) if os.path.exists(user_dir) else []
+    return {"files": files}
+
+
+@app.post("/api/restore")
+async def restore(filename: str, x_token: str | None = Header(None)):
+    user = get_username(x_token)
+    file_path = os.path.join(STORAGE_ROOT, user, filename)
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="Datei nicht gefunden")
+    return FileResponse(path=file_path, filename=filename)
+
+
+if __name__ == "__main__":
+    import uvicorn
+    os.makedirs(STORAGE_ROOT, exist_ok=True)
+    uvicorn.run(app, host="0.0.0.0", port=8000)
+


### PR DESCRIPTION
## Summary
- erweitere `AGENTS.md` um einen Entwicklungsplan für die Server/Client-Architektur
- liefere ein FastAPI-Servergrundgerüst `server.py`
- ergänze `requirements.txt` und Hinweise zum Serverstart in der `README`
- füge `.gitignore` hinzu

## Testing
- `python3 -m py_compile server.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bbc38b1083338166801656f3826b