### PR TITLE
Add admin web interface and CLI management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 pytest_cache/
 storage/
+asgard.db

--- a/README.md
+++ b/README.md
@@ -11,3 +11,15 @@ uvicorn server:app --reload
 
 Die API steht danach auf Port 8000 zur Verfügung.
 
+## Admin-Webinterface
+
+Die Verwaltung der API-Token erfolgt über ein kleines Webinterface unter `/admin`.
+Nach der Installation muss zunächst ein Administrator über die Kommandozeile angelegt werden:
+
+```bash
+python server.py create-admin <benutzername> <passwort>
+```
+
+Anschließend kann der Server gestartet werden (wie oben beschrieben oder mit `python server.py serve`).
+Der Admin meldet sich über das Webformular unter `/admin/login` an (kein HTTP-Auth).
+

--- a/ideas.md
+++ b/ideas.md
@@ -47,6 +47,7 @@ Main Landuage: German
 | **Deduplikation**              | Erkennung gleicher Dateien per Hash (z. B. SHA256 oder `blake3`)              |
 | **Speicherbereinigung**        | Älteste Versionen werden gelöscht, wenn das Limit erreicht ist                |
 | **Storage-Backend flexibel**   | Lokaler Speicher, NFS, Ceph, S3-kompatibel – je nachdem wie fancy du’s willst |
+| **Admin-Webinterface**         | Verwaltung der API-Token über ein Login-geschütztes Webinterface |
 
 ---
 
@@ -122,6 +123,7 @@ AsgardBackup/
 | **Hash-Prüfung**          | Nur geänderte Dateien sichern         |
 | **Restore-Option**        | Per Kommandozeile wiederherstellen    |
 | **Plattformübergreifend** | Windows & Linux, Fokus auf User-Daten |
+| **Admin-Webinterface**    | API-Verwaltung über Login-Seite, Admin wird per CLI erstellt |
 
 ---
 

--- a/server.py
+++ b/server.py
@@ -1,13 +1,95 @@
-from fastapi import FastAPI, UploadFile, File, HTTPException, Header
-from fastapi.responses import FileResponse
+from fastapi import (
+    FastAPI,
+    UploadFile,
+    File,
+    HTTPException,
+    Header,
+    Form,
+    Request,
+    Cookie,
+)
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
 import os
 import secrets
 import hashlib
+import sqlite3
 
 app = FastAPI(title="AsgardBackup Server")
 
 STORAGE_ROOT = os.path.join(os.path.dirname(__file__), "storage")
 TOKENS = {}
+
+DB_PATH = os.path.join(os.path.dirname(__file__), "asgard.db")
+
+
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS admin (username TEXT PRIMARY KEY, password_hash TEXT)"
+    )
+    return conn
+
+
+def create_admin(username: str, password: str) -> None:
+    conn = get_db()
+    h = hashlib.sha256(password.encode()).hexdigest()
+    try:
+        conn.execute(
+            "INSERT INTO admin (username, password_hash) VALUES (?, ?)", (username, h)
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def check_admin(username: str, password: str) -> bool:
+    conn = get_db()
+    try:
+        cur = conn.execute(
+            "SELECT password_hash FROM admin WHERE username = ?", (username,)
+        )
+        row = cur.fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return False
+    return hashlib.sha256(password.encode()).hexdigest() == row[0]
+
+
+ADMIN_SESSIONS: dict[str, str] = {}
+
+
+@app.get("/admin/login", response_class=HTMLResponse)
+async def admin_login_form():
+    return (
+        "<h2>Admin Login</h2>"
+        "<form method='post'>"
+        "<input name='username' placeholder='Benutzername'>"
+        "<input type='password' name='password' placeholder='Passwort'>"
+        "<button type='submit'>Login</button>"
+        "</form>"
+    )
+
+
+@app.post("/admin/login")
+async def admin_login(username: str = Form(...), password: str = Form(...)):
+    if check_admin(username, password):
+        session_id = secrets.token_hex(16)
+        ADMIN_SESSIONS[session_id] = username
+        response = RedirectResponse("/admin", status_code=302)
+        response.set_cookie("session_id", session_id, httponly=True)
+        return response
+    raise HTTPException(status_code=401, detail="Login fehlgeschlagen")
+
+
+@app.get("/admin", response_class=HTMLResponse)
+async def admin_dashboard(session_id: str | None = Cookie(None)):
+    if session_id is None or session_id not in ADMIN_SESSIONS:
+        return RedirectResponse("/admin/login")
+    token_list = "<br>".join(
+        f"{u}: {t}" for t, u in TOKENS.items()
+    ) or "Keine aktiven Tokens"
+    return f"<h2>API Verwaltung</h2><p>{token_list}</p>"
 
 
 def get_username(x_token: str | None = Header(None)) -> str:
@@ -67,7 +149,23 @@ async def restore(filename: str, x_token: str | None = Header(None)):
 
 
 if __name__ == "__main__":
+    import argparse
     import uvicorn
-    os.makedirs(STORAGE_ROOT, exist_ok=True)
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+
+    parser = argparse.ArgumentParser(description="AsgardBackup Server")
+    sub = parser.add_subparsers(dest="cmd")
+    create = sub.add_parser("create-admin", help="Admin anlegen")
+    create.add_argument("username")
+    create.add_argument("password")
+    serve = sub.add_parser("serve", help="Server starten")
+    serve.add_argument("--host", default="0.0.0.0")
+    serve.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    if args.cmd == "create-admin":
+        create_admin(args.username, args.password)
+        print("Admin erstellt")
+    else:
+        os.makedirs(STORAGE_ROOT, exist_ok=True)
+        uvicorn.run(app, host=args.host, port=args.port)
 


### PR DESCRIPTION
## Summary
- create CLI management command to create admin users
- add web-based admin interface with login form
- document admin workflow and CLI usage
- ignore SQLite DB

## Testing
- `python -m py_compile server.py`
- `python server.py --help`
- `python server.py create-admin testuser password`
- `python server.py serve --port 9000` *(started & stopped)*


------
https://chatgpt.com/codex/tasks/task_e_6878c31902508333b68fadedf7872730