### PR TITLE
Implementierung einfacher Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,23 @@ python server.py create-admin <benutzername> <passwort>
 Anschließend kann der Server gestartet werden (wie oben beschrieben oder mit `python server.py serve`).
 Der Admin meldet sich über das Webformular unter `/admin/login` an (kein HTTP-Auth).
 
+## Clients
+
+Für Linux steht eine Kommandozeile zur Verfügung, für Windows eine kleine GUI.
+
+- **CLI (Linux):**
+  ```bash
+  python client_cli.py login --server http://<server>:8000
+  python client_cli.py upload <Datei>
+  ```
+  Nach dem ersten Login wird der erhaltene Token in `~/.asgard_client.json` gespeichert.
+
+- **GUI (Windows):**
+  ```bash
+  python client_gui.py
+  ```
+  Dort können Serveradresse und API‑Token eingegeben sowie Dateien hochgeladen und wiederhergestellt werden.
+
 
 ## Feature-Checkliste
 

--- a/client_cli.py
+++ b/client_cli.py
@@ -1,0 +1,142 @@
+import argparse
+import os
+import json
+import hashlib
+import requests
+from pathlib import Path
+
+CONFIG_PATH = Path.home() / ".asgard_client.json"
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(cfg):
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
+def ensure_token(server: str) -> str:
+    cfg = load_config()
+    token = cfg.get("token")
+    if token:
+        return token
+    username = os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    resp = requests.post(f"{server}/api/login", params={"username": username})
+    resp.raise_for_status()
+    token = resp.json()["token"]
+    cfg["server"] = server
+    cfg["token"] = token
+    save_config(cfg)
+    return token
+
+
+def cmd_login(args):
+    token = ensure_token(args.server)
+    print(f"Token gespeichert: {token}")
+
+
+def file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def cmd_upload(args):
+    cfg = load_config()
+    server = args.server or cfg.get("server")
+    if not server:
+        raise SystemExit("Serveradresse nicht angegeben")
+    token = cfg.get("token")
+    if not token:
+        token = ensure_token(server)
+    path = Path(args.file)
+    if not path.is_file():
+        raise SystemExit("Datei nicht gefunden")
+    fh = file_hash(path)
+    check = requests.post(
+        f"{server}/api/check",
+        params={"filename": path.name, "filehash": fh},
+        headers={"X-Token": token},
+    )
+    check.raise_for_status()
+    if check.json().get("exists"):
+        print("Datei bereits vorhanden, überspringe Upload")
+        return
+    with open(path, "rb") as f:
+        up = requests.post(
+            f"{server}/api/upload",
+            files={"file": (path.name, f)},
+            headers={"X-Token": token, "username": os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"},
+        )
+    up.raise_for_status()
+    print(up.json())
+
+
+def cmd_list(args):
+    cfg = load_config()
+    server = args.server or cfg.get("server")
+    token = cfg.get("token")
+    if not server or not token:
+        raise SystemExit("Bitte zuerst login ausführen")
+    resp = requests.get(f"{server}/api/list", headers={"X-Token": token})
+    resp.raise_for_status()
+    for fname, versions in resp.json()["files"].items():
+        print(fname + ":" )
+        for v in versions:
+            print("  " + v)
+
+
+def cmd_restore(args):
+    cfg = load_config()
+    server = args.server or cfg.get("server")
+    token = cfg.get("token")
+    if not server or not token:
+        raise SystemExit("Bitte zuerst login ausführen")
+    data = {"filename": args.filename}
+    if args.version:
+        data["version"] = args.version
+    resp = requests.post(f"{server}/api/restore", params=data, headers={"X-Token": token})
+    resp.raise_for_status()
+    out_path = Path(args.output or args.filename)
+    with open(out_path, "wb") as f:
+        f.write(resp.content)
+    print(f"Datei gespeichert unter {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="AsgardBackup CLI")
+    parser.add_argument("--server", help="Serveradresse, z.B. http://localhost:8000")
+    sub = parser.add_subparsers(dest="cmd")
+
+    login = sub.add_parser("login", help="Token vom Server holen")
+    login.set_defaults(func=cmd_login)
+
+    upload = sub.add_parser("upload", help="Datei hochladen")
+    upload.add_argument("file")
+    upload.set_defaults(func=cmd_upload)
+
+    ls = sub.add_parser("list", help="Dateien auflisten")
+    ls.set_defaults(func=cmd_list)
+
+    restore = sub.add_parser("restore", help="Datei wiederherstellen")
+    restore.add_argument("filename")
+    restore.add_argument("--version")
+    restore.add_argument("--output", help="Zielpfad")
+    restore.set_defaults(func=cmd_restore)
+
+    args = parser.parse_args()
+    if not args.cmd:
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/client_gui.py
+++ b/client_gui.py
@@ -1,0 +1,141 @@
+import os
+import json
+import hashlib
+import requests
+from pathlib import Path
+import tkinter as tk
+from tkinter import filedialog, messagebox
+
+CONFIG_PATH = Path.home() / ".asgard_client.json"
+
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {}
+
+
+def save_config(cfg):
+    with open(CONFIG_PATH, "w", encoding="utf-8") as f:
+        json.dump(cfg, f)
+
+
+def ensure_token(server: str) -> str:
+    cfg = load_config()
+    token = cfg.get("token")
+    if token:
+        return token
+    username = os.environ.get("USERNAME") or os.environ.get("USER") or "unknown"
+    resp = requests.post(f"{server}/api/login", params={"username": username})
+    resp.raise_for_status()
+    token = resp.json()["token"]
+    cfg["server"] = server
+    cfg["token"] = token
+    save_config(cfg)
+    return token
+
+
+class App(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("AsgardBackup Client")
+        cfg = load_config()
+        self.server_var = tk.StringVar(value=cfg.get("server", ""))
+        self.token_var = tk.StringVar(value=cfg.get("token", ""))
+
+        tk.Label(self, text="Server-Adresse").grid(row=0, column=0, sticky="w")
+        tk.Entry(self, textvariable=self.server_var, width=40).grid(row=0, column=1)
+        tk.Label(self, text="API Token").grid(row=1, column=0, sticky="w")
+        tk.Entry(self, textvariable=self.token_var, width=40).grid(row=1, column=1)
+        tk.Button(self, text="Login", command=self.login).grid(row=2, column=0, pady=5)
+        tk.Button(self, text="Datei hochladen", command=self.upload).grid(row=2, column=1, pady=5)
+        tk.Button(self, text="Dateien auflisten", command=self.list_files).grid(row=3, column=0, pady=5)
+        tk.Button(self, text="Wiederherstellen", command=self.restore).grid(row=3, column=1, pady=5)
+        self.output = tk.Text(self, height=10, width=60)
+        self.output.grid(row=4, column=0, columnspan=2, pady=5)
+
+    def login(self):
+        server = self.server_var.get()
+        if not server:
+            messagebox.showerror("Fehler", "Server-Adresse fehlt")
+            return
+        token = ensure_token(server)
+        self.token_var.set(token)
+        messagebox.showinfo("Info", "Token gespeichert")
+
+    def upload(self):
+        server = self.server_var.get()
+        token = self.token_var.get()
+        if not server or not token:
+            messagebox.showerror("Fehler", "Bitte zuerst Login durchführen")
+            return
+        path = filedialog.askopenfilename()
+        if not path:
+            return
+        filename = os.path.basename(path)
+        h = hashlib.sha256(Path(path).read_bytes()).hexdigest()
+        check = requests.post(
+            f"{server}/api/check",
+            params={"filename": filename, "filehash": h},
+            headers={"X-Token": token},
+        )
+        check.raise_for_status()
+        if check.json().get("exists"):
+            messagebox.showinfo("Info", "Datei bereits vorhanden")
+            return
+        with open(path, "rb") as f:
+            resp = requests.post(
+                f"{server}/api/upload",
+                files={"file": (filename, f)},
+                headers={"X-Token": token, "username": os.environ.get("USERNAME") or os.environ.get("USER") or "unknown"},
+            )
+        resp.raise_for_status()
+        messagebox.showinfo("Erfolg", "Upload abgeschlossen")
+
+    def list_files(self):
+        server = self.server_var.get()
+        token = self.token_var.get()
+        if not server or not token:
+            messagebox.showerror("Fehler", "Bitte zuerst Login durchführen")
+            return
+        resp = requests.get(f"{server}/api/list", headers={"X-Token": token})
+        resp.raise_for_status()
+        self.output.delete(1.0, tk.END)
+        data = resp.json()["files"]
+        for fname, versions in data.items():
+            self.output.insert(tk.END, f"{fname}\n")
+            for v in versions:
+                self.output.insert(tk.END, f"  {v}\n")
+
+    def restore(self):
+        server = self.server_var.get()
+        token = self.token_var.get()
+        if not server or not token:
+            messagebox.showerror("Fehler", "Bitte zuerst Login durchführen")
+            return
+        filename = filedialog.askopenfilename(title="Datei wählen für Restore")
+        if not filename:
+            return
+        name = os.path.basename(filename)
+        resp = requests.post(
+            f"{server}/api/restore",
+            params={"filename": name},
+            headers={"X-Token": token},
+        )
+        resp.raise_for_status()
+        out_path = filedialog.asksaveasfilename(initialfile=name)
+        if not out_path:
+            return
+        with open(out_path, "wb") as f:
+            f.write(resp.content)
+        messagebox.showinfo("Fertig", f"Gespeichert unter {out_path}")
+
+
+def main():
+    app = App()
+    app.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 python-multipart
+requests


### PR DESCRIPTION
## Zusammenfassung
- füge `client_cli.py` für eine Kommandozeile unter Linux hinzu
- füge `client_gui.py` als kleine Tkinter-GUI für Windows hinzu
- erweitere `requirements.txt` um `requests`
- ergänze README um Hinweise zur Nutzung der Clients

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile client_cli.py client_gui.py server.py`
- `python client_cli.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6878d51602688333b3dd2af82e0da6b3