### PR TITLE
Update README for admin creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ Dabei wird `git pull` ausgefuehrt, die Abhaengigkeiten werden aktualisiert und d
 ## Admin-Webinterface
 
 Die Verwaltung der API-Token erfolgt über ein kleines Webinterface unter `/admin`.
-Nach der Installation muss zunächst ein Administrator über die Kommandozeile angelegt werden:
+Nach der Installation muss zunächst ein Administrator über die Kommandozeile angelegt werden.
+Da die Datenbank im Installationsverzeichnis liegt, sind hierfür Root-Rechte notwendig.
+Nutze dabei explizit das Python der eingerichteten venv:
 
 ```bash
-python server.py create-admin <benutzername> <passwort>
+sudo ./venv/bin/python server.py create-admin <benutzername> <passwort>
 ```
 
 Anschließend kann der Server gestartet werden (wie oben beschrieben oder mit `python server.py serve`).


### PR DESCRIPTION
## Summary
- document that creating an admin requires root privileges and the venv's Python

## Testing
- `python -m py_compile server.py client_cli.py client_gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e128689483338c4486343eb827ec