### PR TITLE
Verbesserte Dateiansicht im Windows-Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ Für Linux steht eine Kommandozeile zur Verfügung, für Windows eine kleine GUI
   ```bash
   python client_gui.py
   ```
-  Dort können Serveradresse und API‑Token eingegeben sowie Dateien hochgeladen und wiederhergestellt werden.
-
+  Die Oberfläche zeigt links die vorhandenen Dateien und rechts die zugehörigen Versionen.
+  Oben wird die aktuell ausgewählte Version eingeblendet.
+  
 
 ## Feature-Checkliste
 


### PR DESCRIPTION
## Zusammenfassung
- Windows-GUI zu einer Explorer-Ansicht mit Dateiliste und Versionen umgebaut
- gewaehlte Version wird nun im oberen Bereich angezeigt
- README ergaenzt um Hinweise zur neuen Oberflaeche

## Testing
- `python -m py_compile client_gui.py client_cli.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_6878e48466a0833393f75390bec90bf7