### PR TITLE
Automatisches Bilderbackup und neuer Restore-Dialog

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Für Linux steht eine Kommandozeile zur Verfügung, für Windows eine kleine GUI
   ```
   Die Oberfläche zeigt links die vorhandenen Dateien und rechts die zugehörigen Versionen.
   Oben wird die aktuell ausgewählte Version eingeblendet.
+  Nach dem Login wird automatisch der Windows-Bilderordner gesichert. Zudem kann der Ordner über den Button "Bilder-Backup" manuell hochgeladen werden.
+  Beim Wiederherstellen zeigt eine Fortschrittsanzeige den Download-Status an.
   
 
 ## Feature-Checkliste


### PR DESCRIPTION
## Zusammenfassung
- Windows-GUI erweitert: Button und Auto-Backup des Bilderordners
- Restore-Vorgang zeigt nun einen Fortschrittsbalken
- README um Hinweise zu den neuen Funktionen ergänzt

## Testanweisungen
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6878e83850b08333afffe765f5d1f4bb